### PR TITLE
SB-22256: Schema change for enabling Examination Papers

### DIFF
--- a/kp_schemas/content/1.0/schema.json
+++ b/kp_schemas/content/1.0/schema.json
@@ -1142,7 +1142,7 @@
                 "Course",
                 "Practice Question Set",
                 "eTextbook",
-                "Exam Paper",
+                "Question Paper",
                 "Teacher Resource",
                 "Course Assessment",
                 "Digital Textbook",

--- a/kp_schemas/content/1.0/schema.json
+++ b/kp_schemas/content/1.0/schema.json
@@ -171,6 +171,7 @@
             "type": "string",
             "enum": [
                 "Default",
+                "Private",
                 "Parent"
             ],
             "default": "Default"
@@ -1141,6 +1142,7 @@
                 "Course",
                 "Practice Question Set",
                 "eTextbook",
+                "Exam Paper",
                 "Teacher Resource",
                 "Course Assessment",
                 "Digital Textbook",

--- a/neo4j_schemas/collection_definition.json
+++ b/neo4j_schemas/collection_definition.json
@@ -3039,6 +3039,7 @@
                     "range": [
                         "Textbook",
                         "TV Lesson",
+                        "Exam Paper",
                         "Previous Board Exam Papers",
                         "Pedagogy Flow",
                         "Marking Scheme Rubric",

--- a/neo4j_schemas/collection_definition.json
+++ b/neo4j_schemas/collection_definition.json
@@ -3039,7 +3039,7 @@
                     "range": [
                         "Textbook",
                         "TV Lesson",
-                        "Exam Paper",
+                        "Question Paper",
                         "Previous Board Exam Papers",
                         "Pedagogy Flow",
                         "Marking Scheme Rubric",

--- a/neo4j_schemas/content_definition.json
+++ b/neo4j_schemas/content_definition.json
@@ -3168,6 +3168,7 @@
             "eTextbook",
             "Teacher Resource",
             "Course Assessment",
+            "Exam Paper",
             "Digital Textbook",
             "Content Playlist",
             "Template",

--- a/neo4j_schemas/content_definition.json
+++ b/neo4j_schemas/content_definition.json
@@ -3168,7 +3168,7 @@
             "eTextbook",
             "Teacher Resource",
             "Course Assessment",
-            "Exam Paper",
+            "Question Paper",
             "Digital Textbook",
             "Content Playlist",
             "Template",

--- a/neo4j_schemas/content_image_definition.json
+++ b/neo4j_schemas/content_image_definition.json
@@ -3167,6 +3167,7 @@
             "eTextbook",
             "Teacher Resource",
             "Course Assessment",
+            "Question Paper",
             "Digital Textbook",
             "Content Playlist",
             "Template",
@@ -3177,6 +3178,7 @@
             "Textbook Unit"
           ],
           "defaultValue": "",
+          "visibility": ""
           "renderingHints": "{ 'inputType': 'text',  'order': 14 }",
           "indexed": true,
           "draft": false


### PR DESCRIPTION
Schema changes for the addition of a new `primaryCategory` called "Question Paper", with a new `visibility` option called "Private"

Is this sufficient to enable Exam Papers as a new category?