### PR TITLE
SB-22258, SB-22259: Configurable editor templates for non-interactive questions

### DIFF
--- a/src/app/client/src/app/modules/shared/services/config/editor.config.json
+++ b/src/app/client/src/app/modules/shared/services/config/editor.config.json
@@ -573,6 +573,30 @@
             "FlagDraft",
             "FlagReview"
         ],
+        "defaultStates": {
+            "nonInteractiveQuestions": {                
+                "mtf": {
+                    "questionBody": "<p>Match the following:</p><table style='border-collapse: collapse; width: 100%; height: 36px;' border='1'><tbody><tr style='height: 18px;'><td style='width: 50%; height: 18px; text-align: center;'><strong>Column 1</strong></td><td style='width: 50%; height: 18px; text-align: center;'><strong>Column 2</strong></td></tr><tr style='height: 18px;'><td style='width: 50%; height: 18px; text-align: center;'></td><td style='width: 50%; height: 18px; text-align: center;'></td></tr></tbody></table>",
+                    "answerBody": "<p>Match the following:</p><table style='border-collapse: collapse; width: 100%; height: 36px;' border='1'><tbody><tr style='height: 18px;'><td style='width: 50%; height: 18px; text-align: center;'><strong>Column 1</strong></td><td style='width: 50%; height: 18px; text-align: center;'><strong>Column 2</strong></td></tr><tr style='height: 18px;'><td style='width: 50%; height: 18px; text-align: center;'></td><td style='width: 50%; height: 18px; text-align: center;'></td></tr></tbody></table>"
+                },
+                "ftb": {
+                    "questionBody": "",
+                    "answerBody": ""
+                },
+                "vsa": {
+                    "questionBody": "",
+                    "answerBody": ""
+                },
+                "sa": {
+                    "questionBody": "",
+                    "answerBody": ""
+                },
+                "la": {
+                    "questionBody": "",
+                    "answerBody": ""
+                }    
+            }            
+        },
         "WINDOW_CONFIG": {
             "baseURL": "",
             "modalId": "contentEditor",

--- a/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
@@ -62,7 +62,8 @@ export class BulkUploadComponent implements OnInit {
   public bulkUploadErrorMsgs = [];
   public bulkUploadValidationError = '';
   public levels = [];
-  public sampleMetadataCsvUrl: string = (<HTMLInputElement>document.getElementById('portalCloudStorageUrl')).value.split(',')  + 'bulk-content-upload-format.csv';
+  // public sampleMetadataCsvUrl: string = (<HTMLInputElement>document.getElementById('portalCloudStorageUrl')).value.split(',')  + 'bulk-content-upload-format.csv';
+  public sampleMetadataCsvUrl: string = 'bulk-content-upload-format.csv';
   public telemetryInteractCdata: any;
   public telemetryInteractPdata: any;
   public telemetryInteractObject: any;

--- a/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
@@ -62,8 +62,7 @@ export class BulkUploadComponent implements OnInit {
   public bulkUploadErrorMsgs = [];
   public bulkUploadValidationError = '';
   public levels = [];
-  // public sampleMetadataCsvUrl: string = (<HTMLInputElement>document.getElementById('portalCloudStorageUrl')).value.split(',')  + 'bulk-content-upload-format.csv';
-  public sampleMetadataCsvUrl: string = 'bulk-content-upload-format.csv';
+  public sampleMetadataCsvUrl: string = (<HTMLInputElement>document.getElementById('portalCloudStorageUrl')).value.split(',')  + 'bulk-content-upload-format.csv';  
   public telemetryInteractCdata: any;
   public telemetryInteractPdata: any;
   public telemetryInteractObject: any;

--- a/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
@@ -62,7 +62,7 @@ export class BulkUploadComponent implements OnInit {
   public bulkUploadErrorMsgs = [];
   public bulkUploadValidationError = '';
   public levels = [];
-  public sampleMetadataCsvUrl: string = (<HTMLInputElement>document.getElementById('portalCloudStorageUrl')).value.split(',')  + 'bulk-content-upload-format.csv';  
+  public sampleMetadataCsvUrl: string = (<HTMLInputElement>document.getElementById('portalCloudStorageUrl')).value.split(',')  + 'bulk-content-upload-format.csv';
   public telemetryInteractCdata: any;
   public telemetryInteractPdata: any;
   public telemetryInteractObject: any;

--- a/src/app/client/src/app/modules/sourcing/components/question-creation/question-creation.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/question-creation/question-creation.component.ts
@@ -182,15 +182,17 @@ export class QuestionCreationComponent implements OnInit, AfterViewInit, OnChang
     config,
     channel: this.sessionContext.channel
     };
-    this.editorState = {
-      question : '',
-      answer: '',
+    this.editorState= {
+      question : this.configService.editorConfig.CONTENT_EDITOR.defaultStates.nonInteractiveQuestions[this.sessionContext.questionType].questionBody,
+      answer : this.configService.editorConfig.CONTENT_EDITOR.defaultStates.nonInteractiveQuestions[this.sessionContext.questionType].answerBody,
       solutions: ''
     };
     this.manageFormConfiguration();
     if (this.questionMetaData && this.questionMetaData.data) {
-      this.editorState.question = this.questionMetaData.data.editorState.question;
-      this.editorState.answer = this.questionMetaData.data.editorState.answer;
+      if(this.questionMetaData.data.editorState.question)
+        this.editorState.question = this.questionMetaData.data.editorState.question;
+      if(this.questionMetaData.data.editorState.answer)  
+        this.editorState.answer = this.questionMetaData.data.editorState.answer;
       if (!_.isEmpty(this.questionMetaData.data.editorState.solutions)) {
         const editor_state = this.questionMetaData.data.editorState;
         this.editorState.solutions = editor_state.solutions[0].value;

--- a/src/app/client/src/app/modules/sourcing/components/resource-template/resource-template.component.html
+++ b/src/app/client/src/app/modules/sourcing/components/resource-template/resource-template.component.html
@@ -73,29 +73,43 @@
     {{resourceService.frmelmnts.lbl.selectQuestionType}}
   </div>
   <div class="sb-modal-content">
-    <div class="py-10">
+    <div class="py-10 d-flex flex-dr flex-jc-space-around">
+      <div class="d-flex flex-dc">
+      <h4 class="my-10">Non-Interactive</h4>
+      <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
+        <input type="radio" id="mtf" name="questionType" (click)="setQuestionType('MTF')">
+        <label for="mtf">MTF - Match The Following</label>
+      </div>
+      <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
+        <input type="radio" id="ftb" name="questionType" (click)="setQuestionType('FTB')">
+        <label for="ftb">FTB - Fill in the Blank</label>
+      </div>   
       <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
         <input type="radio" id="vsa" name="questionType" (click)="setQuestionType('VSA')">
         <label for="vsa">VSA - Practice Sets</label>
-      </div>
+      </div>   
       <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
         <input type="radio" id="sa" name="questionType" (click)="setQuestionType('SA')">
         <label for="sa">SA - Practice Sets</label>
-      </div>
+      </div>   
       <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
         <input type="radio" id="la" name="questionType" (click)="setQuestionType('LA')">
         <label for="la">LA - Practice Sets</label>
-      </div>
-      <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
-        <input type="radio" id="mcq" name="questionType" (click)="setQuestionType('MCQ')">
-        <label for="mcq">MCQ - Practice Sets</label>
-      </div>
+      </div>  
       <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
         <input type="radio" id="curiosity" name="questionType" (click)="setQuestionType('CuriosityQuestion')">
         <label for="curiosity">Curiosity Sets</label>
       </div>
     </div>
-  </div>
+    <div class="d-flex flex-dc">
+      <h4 class="my-10">Interactive</h4>   
+      <div class="sb-radio-btn-checkbox sb-radio-btn-primary">
+        <input type="radio" id="mcq" name="questionType" (click)="setQuestionType('MCQ')">
+        <label for="mcq">MCQ - Practice Sets</label>
+      </div>
+    </div>
+    </div>
+  </div>  
   <div class="sb-modal-actions">
     <button class="sb-btn sb-btn-normal" [ngClass]="{'sb-btn-primary': showButton, 'sb-btn-disabled': !showButton}" (click)="submit()"
     appTelemetryInteract


### PR DESCRIPTION
1. Makes changes in `editor.config.json` to add default question and answer bodies
2. There are loaded upon content editor initialisation inside the **Question Creation** component
3. Uses an **HTML table** for the Match The Following question to be able to **permit images being added in both columns** of a non-interactive MTF question
4. Default templates are configurable by changing the values inside `editor.config.json`