### PR TITLE
Issue #SB-24470 fix: sourcing org name is prefilled as copyright fiel…

### DIFF
--- a/src/app/client/package.json
+++ b/src/app/client/package.json
@@ -43,7 +43,7 @@
     "@project-sunbird/ckeditor-build-classic": "0.0.4",
     "@project-sunbird/client-services": "^3.6.11",
     "@project-sunbird/common-consumption-v8": "3.6.4",
-    "@project-sunbird/sunbird-collection-editor": "4.0.2",
+    "@project-sunbird/sunbird-collection-editor": "4.0.4",
     "@project-sunbird/sunbird-pdf-player-v8": "3.8.1",
     "@project-sunbird/sunbird-quml-player-v8": "^3.9.27",
     "@project-sunbird/sunbird-video-player-v8": "3.7.5",

--- a/src/app/client/src/app/modules/sourcing/components/question-set-editor/question-set-editor.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/question-set-editor/question-set-editor.component.ts
@@ -231,7 +231,8 @@ export class QuestionSetEditorComponent implements OnInit {
         cloudStorageUrls : this.userService.cloudStorageUrls
       },
       config: {
-        mode: this.getEditorMode()
+        mode: this.getEditorMode(),
+        setDefaultCopyRight: false
       }
     };
     if (this.showQuestionEditor) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24470" title="SB-24470" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-24470</a>  sourcing org name is prefilled as copyright field in Demo Question set editor for the external contribution org users.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…d in Demo Question set editor for the external contribution org users.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

