### PR TITLE
Issue #SB-24533 feat:Consistent labels for submitting assets for revi…

### DIFF
--- a/src/app/client/src/app/modules/sourcing/components/content-editor/content-editor.component.html
+++ b/src/app/client/src/app/modules/sourcing/components/content-editor/content-editor.component.html
@@ -72,7 +72,7 @@
                   [telemetryInteractObject]="telemetryInteractObject"
                   [telemetryInteractCdata]="telemetryInteractCdata"
                   [telemetryInteractPdata]="telemetryInteractPdata"
-                >{{resourceService.frmelmnts.btn.accept}}</button>
+                >{{resourceService.frmelmnts.btn.submitForApproval}}</button>
                 <button id="submitContent" suiPopup popupText="{{'Edit'}}" [popupPlacement]="'top'" *ngIf="visibility && visibility.showEdit" class="sb-btn sb-btn-normal sb-btn-outline-primary mr-8" (click)="loadContentEditor()"
                 appTelemetryInteract
                   [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('publish', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.submit, telemetryPageId)"
@@ -86,7 +86,7 @@
                   [telemetryInteractObject]="telemetryInteractObject"
                   [telemetryInteractCdata]="telemetryInteractCdata"
                   [telemetryInteractPdata]="telemetryInteractPdata"
-                >{{isIndividualAndNotSample() ? 'Publish' : 'Submit' }}</button>
+                >{{ sessionContext.sampleContent ? resourceService.frmelmnts.btn.submit : resourceService.frmelmnts.btn.submitForReview }}</button>
                 <button id="sendForCorrections" suiPopup popupText="Send back for corrections" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSendForCorrections" class="sb-btn sb-btn-normal sb-btn-outline-primary mr-10" (click)="popupAction='sendForCorrections';showRequestChangesPopup = true"
                   appTelemetryInteract
                     [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('send_back_for_corrections', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch, telemetryPageId)"
@@ -101,7 +101,7 @@
                   [telemetryInteractObject]="telemetryInteractObject"
                   [telemetryInteractCdata]="telemetryInteractCdata"
                   [telemetryInteractPdata]="telemetryInteractPdata"
-                >{{resourceService.frmelmnts.btn.approve}}</button>
+                >{{resourceService.frmelmnts.btn.publishToConsume}}</button>
                 <button id="rejectContent" suiPopup popupText="{{resourceService.frmelmnts.lbl.contentRejectMessage}}" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSourcingActionButtons" class="sb-btn sb-btn-error sb-btn-normal mr-8" (click)="popupAction='rejectContent'; showRequestChangesPopup = true"
                 appTelemetryInteract
                   [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('reject', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch, telemetryPageId)"

--- a/src/app/client/src/app/modules/sourcing/components/content-uploader/content-uploader.component.html
+++ b/src/app/client/src/app/modules/sourcing/components/content-uploader/content-uploader.component.html
@@ -72,14 +72,14 @@
                 [telemetryInteractObject]="telemetryInteractObject"
                 [telemetryInteractCdata]="telemetryInteractCdata"
                 [telemetryInteractPdata]="telemetryInteractPdata"
-              >{{resourceService.frmelmnts.btn.accept}}</button>
+              >{{resourceService.frmelmnts.btn.submitForApproval}}</button>
               <button id="submitContent" suiPopup popupText="{{sessionContext.currentOrgRole === 'individual' ? 'Publish' : 'Send For Review' }}" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSubmit" class="sb-btn sb-btn-secondary sb-btn-normal" (click)="isIndividualAndNotSample() ? showEditform('publish') : showEditform('review');"
               appTelemetryInteract
                 [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('publish', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.submit, telemetryPageId)"
                 [telemetryInteractObject]="telemetryInteractObject"
                 [telemetryInteractCdata]="telemetryInteractCdata"
                 [telemetryInteractPdata]="telemetryInteractPdata"
-              >{{isIndividualAndNotSample() ? 'Publish' : 'Submit' }}</button>
+              >{{ sessionContext.sampleContent ? resourceService.frmelmnts.btn.submit : resourceService.frmelmnts.btn.submitForReview }}</button>
               <button id="sendForCorrections" suiPopup popupText="Send back for corrections" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSendForCorrections" class="sb-btn sb-btn-normal sb-btn-outline-primary mr-10" (click)="popupAction='sendForCorrections';showRequestChangesPopup = true"
                 appTelemetryInteract
                   [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('send_back_for_corrections', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch, telemetryPageId)"
@@ -94,7 +94,7 @@
                 [telemetryInteractObject]="telemetryInteractObject"
                 [telemetryInteractCdata]="telemetryInteractCdata"
                 [telemetryInteractPdata]="telemetryInteractPdata"
-              >{{resourceService.frmelmnts.btn.approve}}</button>
+              >{{resourceService.frmelmnts.btn.publishToConsume}}</button>
               <button id="rejectContent" suiPopup popupText="{{resourceService.frmelmnts.lbl.contentRejectMessage}}" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSourcingActionButtons" class="sb-btn sb-btn-error sb-btn-normal mr-8" (click)="popupAction='rejectContent'; showRequestChangesPopup = true"
               appTelemetryInteract
                 [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('reject', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch, telemetryPageId)"

--- a/src/app/client/src/app/modules/sourcing/components/question-list/question-list.component.html
+++ b/src/app/client/src/app/modules/sourcing/components/question-list/question-list.component.html
@@ -103,14 +103,14 @@
           [telemetryInteractObject]="telemetryEventsInput.telemetryInteractObject"
           [telemetryInteractCdata]="telemetryEventsInput.telemetryInteractCdata"
           [telemetryInteractPdata]="telemetryEventsInput.telemetryInteractPdata"
-          >{{resourceService.frmelmnts.btn.accept}}</button>
+          >{{resourceService.frmelmnts.btn.submitForApproval}}</button>
           <button id="submitContent"  *ngIf="visibility && visibility.showSubmit && resourceStatus === 'Draft'" class="sb-btn sb-btn-secondary sb-btn-normal" (click)="questionCreationChild.buttonTypeHandler('review')"
           appTelemetryInteract
           [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('submit', configService.telemetryLabels.eventType.click, configService.telemetryLabels.eventSubtype.submit,telemetryPageId)"
           [telemetryInteractObject]="telemetryEventsInput.telemetryInteractObject"
           [telemetryInteractCdata]="telemetryEventsInput.telemetryInteractCdata"
           [telemetryInteractPdata]="telemetryEventsInput.telemetryInteractPdata"
-          >{{isIndividualAndNotSample() ? 'Publish' : 'Submit' }}</button>
+          >{{sessionContext.sampleContent ? resourceService.frmelmnts.btn.submit : resourceService.frmelmnts.btn.submitForReview }}</button>
           <button id="sendForCorrections" suiPopup popupText="Send back for corrections" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSourcingActionButtons" class="sb-btn sb-btn-normal mr-10" (click)="popupAction='sendForCorrections';showRequestChangesPopup = true"
             appTelemetryInteract
             [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('send_back_for_corrections', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch, 'content-uploader')"
@@ -124,7 +124,7 @@
             [telemetryInteractObject]="telemetryEventsInput.telemetryInteractObject"
             [telemetryInteractCdata]="telemetryEventsInput.telemetryInteractCdata"
             [telemetryInteractPdata]="telemetryEventsInput.telemetryInteractPdata"
-          >{{resourceService.frmelmnts.btn.approve}}</button>
+          >{{resourceService.frmelmnts.btn.publishToConsume}}</button>
           <button id="rejectContent" suiPopup popupText="{{resourceService.frmelmnts.lbl.contentRejectMessage | interpolate:'{category}': programContext.target_collection_category && programContext.target_collection_category[0]}}" [popupPlacement]="'top'" *ngIf="visibility && visibility.showSourcingActionButtons" class="sb-btn sb-btn-error sb-btn-normal" (click)="popupAction='rejectContent'; showRequestChangesPopup = true"
           appTelemetryInteract
             [telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('reject', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch, telemetryPageId)"

--- a/src/app/client/src/app/modules/sourcing/components/question-set-editor/question-set-editor.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/question-set-editor/question-set-editor.component.ts
@@ -228,7 +228,13 @@ export class QuestionSetEditorComponent implements OnInit {
           isRootOrgAdmin: this.userService.userProfile.rootOrgAdmin
         },
         channelData: this.frameworkService['_channelData'],
-        cloudStorageUrls : this.userService.cloudStorageUrls
+        cloudStorageUrls : this.userService.cloudStorageUrls,
+        labels: {
+          submit_collection_btn_label: this.sessionContext.sampleContent ? this.resourceService.frmelmnts.btn.submit : this.resourceService.frmelmnts.btn.submitForReview,
+          publish_collection_btn_label: this.resourceService.frmelmnts.btn.submitForApproval,
+          sourcing_approve_collection_btn_label: this.resourceService.frmelmnts.btn.publishToConsume,
+          reject_collection_btn_label: this.resourceService.frmelmnts.btn.requestChanges,
+        }
       },
       config: {
         mode: this.getEditorMode(),

--- a/src/app/resourcebundles/data/consumption/en.properties
+++ b/src/app/resourcebundles/data/consumption/en.properties
@@ -1427,6 +1427,8 @@ frmelmnts.lbl.removeUserFromProgramConfirmationMsg=Are you sure you want to remo
 frmelmnts.lbl.correctionsPending=Corrections pending
 frmelmnts.lbl.contributioncorrectionsPending=Contributions corrections pending
 frmelmnts.btn.sendForCorrections=Send back for corrections
+frmelmnts.btn.submitForApproval=Submit for Approval
+frmelmnts.btn.publishToConsume=Publish
 #Content Upload
 frmelmnts.lbl.contentName=Name
 frmelmnts.lbl.contentNameRequired=Name required
@@ -1464,6 +1466,7 @@ frmelmnts.btn.approve=Approve
 frmelmnts.lbl.contentAcceptMessage=Accept Content For {category}
 frmelmnts.lbl.contentRejectMessage=Reject Content For {category}
 frmelmnts.lbl.requestChanges=Request Changes
+frmelmnts.btn.submitForReview=Submit for review
 frmelmnts.lbl.contentEdit=Edit Content
 messages.smsg.contentAcceptMessage.m0001=Content accepted successfully
 messages.emsg.approvingFailed=Approving content failed, please try again later...


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24533" title="SB-24533" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-24533</a>  Consistent labels for submitting assets for review and publish
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…ew and publish

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

