### PR TITLE
SB-24310: Adding org and target specific category metadata in definition

### DIFF
--- a/neo4j_schemas/category_definition.json
+++ b/neo4j_schemas/category_definition.json
@@ -180,6 +180,54 @@
           "defaultValue": "",
           "renderingHints": "",
           "indexed": true
+        },
+        {
+            "propertyName": "orgIdFieldName",
+            "title": "OrgIdFieldName",
+            "description": "Org Id FieldName for Category",
+            "category": "General",
+            "dataType": "Text",
+            "required": true,
+            "displayProperty": "Editable",
+            "defaultValue": "",
+            "renderingHints": "{'inputType': 'text', 'order': 4}",
+            "indexed": true
+        },
+        {
+            "propertyName": "targetIdFieldName",
+            "title": "TargetIdFieldName",
+            "description": "TargetId FieldName for Category",
+            "category": "General",
+            "dataType": "Text",
+            "required": true,
+            "displayProperty": "Editable",
+            "defaultValue": "",
+            "renderingHints": "{'inputType': 'text', 'order': 4}",
+            "indexed": true
+        },
+        {
+            "propertyName": "searchIdFieldName",
+            "title": "SearchIdFieldName",
+            "description": "SearchId FieldName for Category",
+            "category": "General",
+            "dataType": "Text",
+            "required": true,
+            "displayProperty": "Editable",
+            "defaultValue": "",
+            "renderingHints": "{'inputType': 'text', 'order': 4}",
+            "indexed": true
+        },
+        {
+            "propertyName": "searchLabelFieldName",
+            "title": "SearchLabelFieldName",
+            "description": "SearchLabel FieldName for Category",
+            "category": "General",
+            "dataType": "Text",
+            "required": true,
+            "displayProperty": "Editable",
+            "defaultValue": "",
+            "renderingHints": "{'inputType': 'text', 'order': 4}",
+            "indexed": true
         }
       ],
       "inRelations":[],


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24310" title="SB-24310" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-24310</a>  Tagging org and target framework values for assets created under a target collection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Adding org and target specific category metadata in definition

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

