### PR TITLE
Issue #SB-24310 feat: attach framework and targetFwIds to asset

### DIFF
--- a/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/bulk-upload/bulk-upload.component.ts
@@ -481,7 +481,7 @@ export class BulkUploadComponent implements OnInit {
       { name: 'Level 4 Textbook Unit', inputName: 'level4', headerError },
     ];
 
-     const orgFrameworkCategories = _.map(
+     const orgFrameworkCategories = !_.isEmpty(_.get(this.sessionContext.targetCollectionFrameworksData, 'framework')) ? _.map(
        _.omitBy(this.frameworkService.orgFrameworkCategories, category => category.code === 'framework'), category => {
        return {
          name: `Org_FW_${category.code}`,
@@ -489,9 +489,9 @@ export class BulkUploadComponent implements OnInit {
          isArray: true,
          headerError
        };
-     });
+     }) : [];
 
-     const targetFrameworkCategories = _.map(
+     const targetFrameworkCategories = !_.isEmpty(_.get(this.sessionContext.targetCollectionFrameworksData, 'targetFWIds'))  ? _.map(
        _.omitBy(this.frameworkService.targetFrameworkCategories, category => category.code === 'targetFWIds'), category => {
       return {
         name: `Target_FW_${category.code}`,
@@ -499,9 +499,9 @@ export class BulkUploadComponent implements OnInit {
         isArray: true,
         headerError
       };
-    });
+    }) : [];
 
-    this.allowedDynamicColumns = [...orgFrameworkCategories, ...targetFrameworkCategories]; // []
+    this.allowedDynamicColumns = [...orgFrameworkCategories, ...targetFrameworkCategories];
     const validateRow = (row, rowIndex) => {
       if (_.isEmpty(row.level4) && _.isEmpty(row.level3) && _.isEmpty(row.level2) && _.isEmpty(row.level1)) {
         const name = headers.find((r) => r.inputName === 'level1').name || '';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24310" title="SB-24310" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-24310</a>  Tagging org and target framework values for assets created under a target collection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

