### PR TITLE
SB-25052 UI is distorted in the textbook list tab of Project details …

### DIFF
--- a/src/app/client/src/app/modules/shared-feature/components/textbook-list/textbook-list.component.html
+++ b/src/app/client/src/app/modules/shared-feature/components/textbook-list/textbook-list.component.html
@@ -32,7 +32,7 @@
 <div class="sb-pageSection">
 	<div class="sb-bg-color-white pt-5">
 		<div class="sb-table-responsive" *ngIf="!showLoader && collectionsCnt > 0">
-			<table class="sb-table sb-table-striped  sb-table-sortable">
+			<table class="sb-table sb-table-striped  sb-table-sortable sb-table-horizontalscroll">
 				<thead class="sb-table-header sb-table-thead-gray">
 					<tr>
 						<th class="cursor-pointer sb-sorting" (click)="sortCollection('name')">{{resourceService.frmelmnts.lbl.title}} &nbsp;&nbsp;
@@ -68,38 +68,38 @@
 						<th>&nbsp;</th>
 					</tr>
 				</thead>
-				<tbody class="sb-table-body w-100 o-y-auto max-height" *ngIf="collections.length">
-					<tr *ngFor="let data of collections">
-						<td>
-							<div class="sb__ellipsis sb__ellipsis--three sb-color-primary font-weight-bold">
-								{{data.name}}
-							</div>
-						</td>
-						<td>
-							<div>
-								{{data.medium}}
-							</div>
-						</td>
-						<td>
-							<div class="sb__ellipsis sb__ellipsis--three">
-								{{data.gradeLevel}}
-							</div>
-						</td>
-						<td>
-							<div>
-								{{data.subject}}
-							</div>
-						</td>
-						<td>{{ data.chapterCountForContribution || data.chapterCount || 0 }}</td>
-						<td class="fsmall"><span class="d-inline-block mr-5">{{ (data?.pendingBySourceOrg?.length + data.mvcContributionsCount || 0) }}<span class="sb-color-warning"> {{ resourceService?.frmelmnts?.lbl?.approvalPending }}</span></span></td>
-						<td class="text-center"><button type="button"  class="sb-btn sb-btn-normal sb-btn-outline-primary" (click)="viewContribution(data)"
-							appTelemetryInteract
-							[telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('open', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch,telemetryPageId)"
-							[telemetryInteractObject]="telemetryInteractObject"
-							[telemetryInteractCdata]="getTelemetryInteractCdata(data.identifier,'linked_collection')"
-							[telemetryInteractPdata]="telemetryInteractPdata">{{resourceService.frmelmnts.lbl.open}}</button></td>
-					</tr>
-				</tbody>
+					<tbody class="sb-table-body w-100" *ngIf="collections.length">
+						<tr *ngFor="let data of collections">
+							<td>
+								<div class="sb__ellipsis sb__ellipsis--three sb-color-primary font-weight-bold">
+									{{data.name}}
+								</div>
+							</td>
+							<td>
+								<div>
+									{{data.medium}}
+								</div>
+							</td>
+							<td>
+								<div class="sb__ellipsis sb__ellipsis--three">
+									{{data.gradeLevel}}
+								</div>
+							</td>
+							<td>
+								<div>
+									{{data.subject}}
+								</div>
+							</td>
+							<td>{{ data.chapterCountForContribution || data.chapterCount || 0 }}</td>
+							<td class="fsmall"><span class="d-inline-block mr-5">{{ (data?.pendingBySourceOrg?.length + data.mvcContributionsCount || 0) }}<span class="sb-color-warning"> {{ resourceService?.frmelmnts?.lbl?.approvalPending }}</span></span></td>
+							<td class="text-center"><button type="button"  class="sb-btn sb-btn-normal sb-btn-outline-primary" (click)="viewContribution(data)"
+								appTelemetryInteract
+								[telemetryInteractEdata]="programTelemetryService.getTelemetryInteractEdata('open', configService.telemetryLabels.eventType.click,configService.telemetryLabels.eventSubtype.launch,telemetryPageId)"
+								[telemetryInteractObject]="telemetryInteractObject"
+								[telemetryInteractCdata]="getTelemetryInteractCdata(data.identifier,'linked_collection')"
+								[telemetryInteractPdata]="telemetryInteractPdata">{{resourceService.frmelmnts.lbl.open}}</button></td>
+						</tr>
+					</tbody>
 			</table>
 		</div>
 		<div class="mt-12" *ngIf="!showLoader && collectionsCnt === 0">

--- a/src/app/client/src/app/modules/shared-feature/components/textbook-list/textbook-list.component.html
+++ b/src/app/client/src/app/modules/shared-feature/components/textbook-list/textbook-list.component.html
@@ -32,7 +32,7 @@
 <div class="sb-pageSection">
 	<div class="sb-bg-color-white pt-5">
 		<div class="sb-table-responsive" *ngIf="!showLoader && collectionsCnt > 0">
-			<table class="sb-table sb-table-striped  sb-table-sortable sb-table-horizontalscroll">
+			<table class="sb-table sb-table-striped  sb-table-sortable">
 				<thead class="sb-table-header sb-table-thead-gray">
 					<tr>
 						<th class="cursor-pointer sb-sorting" (click)="sortCollection('name')">{{resourceService.frmelmnts.lbl.title}} &nbsp;&nbsp;

--- a/src/app/client/src/assets/styles/pages/_dock.scss
+++ b/src/app/client/src/assets/styles/pages/_dock.scss
@@ -106,12 +106,6 @@ hr {
     &.warning .status__label:before {
       background-color: var(--red-100);
     }
-
-    &.completed .status__label:before {
-      // background-color:var(--secondary-200);
-      // border: 0.25rem solid var(--gray-0);
-    }
-
     .status__label {
       font-size: 0.75rem;
       white-space: normal;
@@ -802,5 +796,26 @@ app-question-set-editor{
 .footer{
   label{
     color: #fff !important;
+  }
+}
+.sb-table-horizontalscroll{
+  thead{
+    tr{
+      display: block;
+      th{
+        width: 200px;
+      }
+    }
+  }
+  tbody{
+    display: block;
+    max-height: 400px !important;
+    overflow-y: auto !important;
+    tr{
+      display: block;
+      td{
+        width: 200px;
+      }
+    }
   }
 }

--- a/src/app/client/src/assets/styles/pages/_dock.scss
+++ b/src/app/client/src/assets/styles/pages/_dock.scss
@@ -798,24 +798,3 @@ app-question-set-editor{
     color: #fff !important;
   }
 }
-.sb-table-horizontalscroll{
-  thead{
-    tr{
-      display: block;
-      th{
-        width: 200px;
-      }
-    }
-  }
-  tbody{
-    display: block;
-    max-height: 400px !important;
-    overflow-y: auto !important;
-    tr{
-      display: block;
-      td{
-        width: 200px;
-      }
-    }
-  }
-}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25052" title="SB-25052" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-25052</a>  UI is distorted in the textbook list tab of Project details page in Chrome version 91.0.4472.77
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…page in Chrome version 91.0.4472.77

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

