### PR TITLE
Issue #SB-27185 fix : Average rating text and start is not aligned equally with the Total plays and average rating count.

### DIFF
--- a/src/app/client/src/app/modules/contribute/components/my-content/my-content.component.html
+++ b/src/app/client/src/app/modules/contribute/components/my-content/my-content.component.html
@@ -91,7 +91,7 @@
                         <dd>{{resourceService.frmelmnts.lbl.averagePlaysPerCount}}</dd>
                     </dl>
                     <dl class="mb-0">
-                        <dt class="fs-1-286 font-weight-bold py-8"><i class="icon star sb-color-yellow fs-0-785" aria-hidden="true"></i>
+                        <dt class="fs-1-286 font-weight-bold py-10"><i class="icon star sb-color-yellow fs-0-785" aria-hidden="true"></i>
                             {{usageDetailsCount.averageRating}}
                         </dt>
                         <dd>{{resourceService.frmelmnts.lbl.averageRating}}</dd>


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

