### PR TITLE
Issue #SB-27188 fix: Framework attribute's text size is smaller than the value below and ui is looking odd.

### DIFF
--- a/src/app/client/src/app/modules/contribute/components/my-content/my-content.component.html
+++ b/src/app/client/src/app/modules/contribute/components/my-content/my-content.component.html
@@ -365,7 +365,7 @@
                             <div class="d-flex">
                                 <div class="pr-20 w-40" *ngIf="item.value?.board.length > 0">
                                     <label
-                                    class="d-block fsmall font-weight-normal">{{resourceService.frmelmnts.lbl.boards}}</label>
+                                    class="d-block fsmall font-weight-600">{{resourceService.frmelmnts.lbl.boards}}</label>
                                     <div class="fnormal">
                                         {{ item.value.board | slice:0:2 }}
                                         <span class="d-none" [attr.id]="'boardList' + i">
@@ -381,7 +381,7 @@
                                 </div>
                                 <div class="pr-20 w-40" *ngIf="item?.value?.medium.length > 0">
                                     <label
-                                        class="d-block fsmall font-weight-normal">{{resourceService.frmelmnts.lbl.medium}}</label>
+                                        class="d-block fsmall font-weight-600">{{resourceService.frmelmnts.lbl.medium}}</label>
                                     <div class="fnormal">
                                         {{ item.value.medium | slice:0:2 }}
                                         <span class="d-none" [attr.id]="'mediumList' + i">
@@ -397,7 +397,7 @@
                                 </div>
                                 <div class="pr-20 w-40" *ngIf="item?.value?.gradeLevel.length > 0">
                                     <label
-                                        class="d-block fsmall font-weight-normal">{{resourceService.frmelmnts.lbl.class}}</label>
+                                        class="d-block fsmall font-weight-600">{{resourceService.frmelmnts.lbl.class}}</label>
                                     <div class="fnormal">
                                         {{ item.value.gradeLevel | slice:0:2 }}
                                         <span class="d-none" [attr.id]="'gradeLevelList' + i">
@@ -413,7 +413,7 @@
                                 </div>
                                 <div class="pr-20 w-40" *ngIf="item?.value?.subject.length > 0">
                                     <label
-                                        class="d-block fsmall font-weight-normal">{{resourceService.frmelmnts.lbl.subject}}</label>
+                                        class="d-block fsmall font-weight-600">{{resourceService.frmelmnts.lbl.subject}}</label>
                                     <div class="fnormal">
                                         {{ item.value.subject | slice:0:2 }}
                                         <span class="d-none" [attr.id]="'subjectList' + i">

--- a/src/app/client/src/app/modules/contribute/components/my-content/my-content.component.scss
+++ b/src/app/client/src/app/modules/contribute/components/my-content/my-content.component.scss
@@ -6,7 +6,7 @@
     padding: 20px;
     width: 50%;
     .fnormal{
-        font-size: 14px !important;
+        font-size: 13px !important;
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27188" title="SB-27188" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-27188</a>  Framework attribute's text size is smaller than the value below and ui is looking odd.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…the value below and ui is looking odd.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

