### PR TITLE
Issue #SB-27480 fix: Submit Review button is doesn't work on Sourcing org admin side when sourcinh user reject the contents

### DIFF
--- a/src/app/client/src/app/modules/sourcing/components/question-list/question-list.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/question-list/question-list.component.ts
@@ -1310,8 +1310,8 @@ export class QuestionListComponent implements OnInit, AfterViewInit, OnDestroy {
   attachContentToTextbook(action) {
 
     let rejectComment = '';
-    if (action === 'reject' && this.FormControl.value.rejectComment.length) {
-      rejectComment = this.FormControl.value.rejectComment;
+    if (action === 'reject' && this.FormControl.value.contentRejectComment.length) {
+      rejectComment = this.FormControl.value.contentRejectComment;
     }
     // tslint:disable-next-line:max-line-length
     this.helperService.manageSourcingActions(action, this.sessionContext, this.programContext, this.sessionContext.textBookUnitIdentifier, this.sessionContext.contentMetadata, rejectComment);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27480" title="SB-27480" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-27480</a>  Submit Review button is doesn't work on Sourcing org admin side when  sourcinh user reject the contents 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

