### PR TITLE
Issue #SB-28778 fix:Board  / Learning Outcome field is not aligned

### DIFF
--- a/src/app/client/src/app/modules/core/components/content-data-form/content-data-form.component.scss
+++ b/src/app/client/src/app/modules/core/components/content-data-form/content-data-form.component.scss
@@ -60,6 +60,8 @@
       }
   }
   .treepicker-parent{
+    margin-bottom: 16px;
+    margin-top: 0;
     .list-border{
       font-size: 0.75rem !important;
       padding: 0.25rem 0.5rem !important;
@@ -67,19 +69,22 @@
       border-radius: 0.1875rem !important;
     }
   }
+  .sb-dropdown{
+    margin-bottom: 16px !important;
+  }
 }
 sui-select{
-border-radius: 0.1875rem !important;
+  border-radius: 0.1875rem !important;
 }
 .dynamic-form .label-html div {
-font-size:0.785rem !important;
-line-height:1.4 !important;
-.font-italic{
   font-size:0.785rem !important;
-}
+  line-height:1.4 !important;
+  .font-italic{
+    font-size:0.785rem !important;
+  }
 }
 .two-column-grid {
-display: grid;
-grid-template-columns: repeat(2, 1fr);
-column-gap: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 2rem;
 }

--- a/src/app/client/src/app/modules/program/components/contributors-list/contributors-list.component.html
+++ b/src/app/client/src/app/modules/program/components/contributors-list/contributors-list.component.html
@@ -17,7 +17,7 @@
         [telemetryInteractPdata]="telemetryInteractPdata">{{resource?.frmelmnts?.lbl?.search}}</button>
     </div>
     <div class="w-100 ml-20">
-      <label class="d-block">{{resource?.frmelmnts?.lbl?.selectContributors?.contributor?.filter?.types}}
+      <label class="d-block font-weight-bold fs-0-785">{{resource?.frmelmnts?.lbl?.selectContributors?.contributor?.filter?.types}}
         <i class="pull-right question circle link icon pull-right" suiPopup popupDelay="500" [popupPlacement]="'left'"
 					popupText="{{resource?.frmelmnts?.lbl?.selectContributors?.contributor?.filter?.tooltip}}"></i>
       </label>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-28778" title="SB-28778" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-28778</a>  Board  / Learning Outcome field is not aligned Properly while project creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…operly while project creation

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

