### PR TITLE
Issue #SB-29745 fix: Project creation form loaded with BMGS for NCERT…

### DIFF
--- a/src/app/client/src/app/modules/program/components/create-program/create-program.component.ts
+++ b/src/app/client/src/app/modules/program/components/create-program/create-program.component.ts
@@ -1224,7 +1224,7 @@ onChangeTargetCollectionCategory() {
   if(this.projectScopeForm.controls && this.projectScopeForm.value) {
     this.projectScopeForm.controls['target_collection_category'].setValue(this.selectedTargetCollection);
     this.projectScopeForm.value.pcollections = [];
-    if (!_.isEmpty(this.projectScopeForm.value.framework)) {
+    if (!_.isEmpty(this.projectScopeForm.value.framework) && _.isEmpty(this.programScope['formFieldProperties'])) {
       this.onFrameworkChange();
     } else {
       this.showTexbooklist();

--- a/src/app/client/src/app/modules/program/components/program-nominations/program-nominations.component.spec.ts
+++ b/src/app/client/src/app/modules/program/components/program-nominations/program-nominations.component.spec.ts
@@ -246,9 +246,10 @@ describe('ProgramNominationsComponent', () => {
   it('#sortCollection() should set nominations value', () => {
     component.direction = 'desc';
     component.nominations = [];
-    spyOn(programsService, 'sortCollection').and.returnValue([]);
+    spyOn(programsService, 'sortCollection').and.callFake(() => {});
     spyOn(component, 'sortCollection').and.callThrough();
     component.sortCollection('name');
+    expect(component.sortCollection).toHaveBeenCalled();
     expect(programsService.sortCollection).toHaveBeenCalled();
     expect(component.direction).toEqual('asc');
     expect(component.sortColumn).toEqual('name');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29745" title="SB-29745" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29745</a>  Project creation form loaded with BMGS for NCERT tenant after the selection of the textbook.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
… tenant after the selection of the textbook.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

