### PR TITLE
Revert "Issue #CO-108 fix: Draft content count is getting displayed on unit node for the Contribution org reviewer and Contribution org contributor before the user with both role create the content"

### DIFF
--- a/src/app/client/src/app/modules/sourcing/components/chapter-list/chapter-list.component.ts
+++ b/src/app/client/src/app/modules/sourcing/components/chapter-list/chapter-list.component.ts
@@ -1705,8 +1705,6 @@ export class ChapterListComponent implements OnInit, OnChanges, OnDestroy, After
       contents = _.filter(contents, leaf => {
         if (prevStatus && leaf.status === 'Draft' && (leaf.prevStatus === 'Review' || leaf.prevStatus === 'Live')) {
           return true;
-        } else if (this.isContributingOrgReviewer() && leaf.status === 'Draft' && !leaf.prevStatus && leaf.createdBy != createdBy) {
-          return false;
         } else {
           return _.includes(status, leaf.status);
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/CO-108" title="CO-108" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CO-108</a>  Draft content count is getting displayed on unit node for the Contribution org  reviewer and Contribution org contributor before the user with both role create the content
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reverts Sunbird-Ed/creation-portal#2179